### PR TITLE
Modification de la logique de récupération de la clé API lors d'une c…

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,15 @@ Vous avez deux options pour utiliser le site du ProjetADE. La première est d’
 | 9 | Suivez les étapes de la section [Sur le site ProjetADE](#sur-le-site-projetade).|
 | 10 | Voilà !|
 
+> [!NOTE]  
+> La clé API va être passée dans l'URL, car autrement cela crée des conflits avec Cloudflare et Nginx.  
+>
+> Si vous hébergez vous-même et que le code retourne une erreur liée à la connexion Socket.IO ou à une clé API indéfinie, vous pouvez utiliser dans `socketio-controleur.js` :  
+> `const cleApi = socket.handshake.headers['cle_api'];`  
+> 
+> Dans ce cas, il faut également modifier le code de ProjetADE-Client, dans le fichier `socketio_client.py`, et utiliser :  
+> `self.sio.connect(self.__lien, headers={"cle_api": self.__cle_api})`.
+
 ## Diagramme des fichiers du NodeJS 
 Pour plus de détails à propos de ce diagramme, consultez notre documentation Word.
 ![Diagramme des fichiers du NodeJS ](./public/img/diagrammefichier.drawio.png)

--- a/controleur/socketio-controleur.js
+++ b/controleur/socketio-controleur.js
@@ -23,7 +23,18 @@ class SocketIOControleur{
         this.io.on('connection', async (socket)=> {
             console.log("connexion")
             try{
+
+                /* 
+                
+                Avec Nginx et Clouflare, le code suivant ne fonctionnait pas, donc je l'ai remplacé par .handshake.query.cle_api en passant la clé directement dans l'url.
+
+                Si vous allez faire passer les paramètres dans les "headers" sur le code du Raspberry Pi, alors utilisez ce code :
                 const cleApi = socket.handshake.headers['cle_api'];
+
+                */
+                const cleApi = socket.handshake.query.cle_api;
+
+                console.log("cle api" + cleApi)
 
                 if (!cleApi) {
                     socket.disconnect(true);


### PR DESCRIPTION
Modification de la logique de récupération de la clé API lors d'une connexion Socket.IO, car cela créait des conflits avec Cloudflare et Nginx (ces services ne permettent pas le passage de la clé dans les headers, comme c'était fait dans le code Python).